### PR TITLE
MurmurHash3.cpp & MurmurHash3.h Changes: Method Prototypes and Linker Errors

### DIFF
--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -91,8 +91,8 @@ FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32 ( const void * key, int len,
-                          uint32_t seed, void * out )
+void MurmurHash3_x86_32 ( const void * key, const int len,
+                          const uint32_t seed, void * out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 4;
@@ -148,7 +148,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 //-----------------------------------------------------------------------------
 
 void MurmurHash3_x86_128 ( const void * key, const int len,
-                           uint32_t seed, void * out )
+                           const uint32_t seed, void * out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 16;

--- a/src/MurmurHash3.h
+++ b/src/MurmurHash3.h
@@ -26,11 +26,11 @@ typedef unsigned __int64 uint64_t;
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x86_32  ( const void * key, const int len, const uint32_t seed, void * out );
 
-void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x86_128 ( const void * key, const int len, const uint32_t seed, void * out );
 
-void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed, void * out );
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #2 
Fixes #3 

[ilink32 Error] Error: Unresolved external 'MurmurHash3_x86_128(const void *, int, unsigned int, void *)' referenced from MAIN.OBJ

[ilink32 Error] Error: Unresolved external 'MurmurHash3_x64_128(const void *, const int, unsigned int, void *)' referenced from MAIN.OBJ

Changed method prototype for the function void MurmurHash3_x86_32 in MurmurHash3.h so it matches format of MurmurHash3_x86_128 and MurmurHash3_x64_128.