### PR TITLE
MurmurHash3.cpp Changes: x86_128 and x86_32 Function Bodies

### DIFF
--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -91,8 +91,8 @@ FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32 ( const void * key, int len,
-                          uint32_t seed, void * out )
+void MurmurHash3_x86_32 ( const void * key, const int len,
+                          const uint32_t seed, void * out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 4;
@@ -148,7 +148,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 //-----------------------------------------------------------------------------
 
 void MurmurHash3_x86_128 ( const void * key, const int len,
-                           uint32_t seed, void * out )
+                           const uint32_t seed, void * out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 16;


### PR DESCRIPTION
Fixes #4 

Change in MurmurHash3.cpp: Changed function bodies of MurmurHash3_x86_32 and MurmurHash3_x86_128 so parameters reflect changes in header.