### PR TITLE
Platform.cpp & Platform.h Changes: Linker Errors with sched.h and strings.h

### DIFF
--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -9,7 +9,7 @@ void testRDTSC ( void )
   printf("%d",(int)temp);
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(_Windows)
 
 #include <windows.h>
 

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -86,8 +86,14 @@ __inline__ unsigned long long int rdtsc()
 #endif
 }
 
-#include <strings.h>
-#define _stricmp strcasecmp
+#if defined (_MSC_VER) || defined(_Windows)
+	#define _stricmp stricmp
+#else
+	#include <strings.h>
+	#define _stricmp strcasecmp
+#endif
+
+
 
 #endif	//	!defined(_MSC_VER)
 


### PR DESCRIPTION
Fixes #8 Linker Errors with sched.h and strings.h

Fixes error: bcc32c Fatal Error Platform.cpp(24): 'sched.h' file not found
Fixes error: bcc32c Fatal Error Platform.h(89):'strings.h' file not found