### PR TITLE
Main.cpp, pstdint.h, & PMurHash.h Changes:  Include stdint.h and stdlib.h

### DIFF
--- a/src/PMurHash.h
+++ b/src/PMurHash.h
@@ -15,13 +15,14 @@
  * any version provided by the system headers or application. */
 
 /* First look for special cases */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1600
   #define MH_UINT32 unsigned long
 #endif
 
 /* If the compiler says it's C99 then take its word for it */
 #if !defined(MH_UINT32) && ( \
-     defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L )
+  (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
+  (defined(_MSC_VER) && _MSC_VER >= 1600) )
   #include <stdint.h>
   #define MH_UINT32 uint32_t
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 #include "AvalancheTest.h"
 #include "DifferentialTest.h"
 #include "PMurHash.h"
-
+#include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
 

--- a/src/pstdint.h
+++ b/src/pstdint.h
@@ -190,7 +190,7 @@
  *  do nothing else.  On the Mac OS X version of gcc this is _STDINT_H_.
  */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_)) )) && !defined (_PSTDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined (_MSC_VER) && _MSC_VER >= 1600) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_)) )) && !defined (_PSTDINT_H_INCLUDED)
 #include <stdint.h>
 #define _PSTDINT_H_INCLUDED
 # ifndef PRINTF_INT64_MODIFIER


### PR DESCRIPTION
Fixes #10 Windows Compiling General 

Use stdint.h since VS 2010. Credit for this change goes to user hcoona on gihub: https://github.com/hcoona/

Fixes error in main.cpp: main.cpp:121:5: error: use of undeclared identifier 'exit' when building with ninja